### PR TITLE
Implement skill-based keyword search

### DIFF
--- a/streamlit_app.py
+++ b/streamlit_app.py
@@ -17,25 +17,61 @@ def download_jobs_db():
         gdown.download(GDRIVE_URL, JOBS_DB_PATH, quiet=False)
 
 # Load hierarchical structure from majors.db
+@st.cache_data
 def load_major_hierarchy():
     conn = sqlite3.connect(MAJOR_DB_PATH)
-    df = pd.read_sql("SELECT DISTINCT School, Department, [Major Name] AS Major FROM majors;", conn)
+    df = pd.read_sql(
+        "SELECT DISTINCT School, Department, [Major Name] AS Major FROM majors;",
+        conn,
+    )
     conn.close()
     return df
 
 # Get keywords for selected major
+@st.cache_data
 def load_major_keywords(major):
+    """Return job title and skill keywords for the selected major."""
     conn = sqlite3.connect(MAP_DB_PATH)
-    df = pd.read_sql("SELECT * FROM major_job_map WHERE major = ?;", conn, params=(major,))
+    df = pd.read_sql(
+        "SELECT job_title_keyword, skill_keyword FROM major_job_map WHERE major = ?;",
+        conn,
+        params=(major,),
+    )
     conn.close()
     job_keywords = df[df["job_title_keyword"].notnull()]["job_title_keyword"].tolist()
-    return job_keywords
+    skill_keywords = df[df["skill_keyword"].notnull()]["skill_keyword"].tolist()
+    return job_keywords, skill_keywords
 
-# Build SQL query to match job title only
-def build_query(keywords):
-    conditions = " OR ".join(["title LIKE ?" for _ in keywords])
-    sql = f"SELECT * FROM job_postings WHERE {conditions} LIMIT 100;"
-    params = [f"%{kw}%" for kw in keywords]
+# Build SQL query combining title and skill filters
+def build_query(title_keywords, skill_keywords):
+    """Return SQL and parameters to search by job title and skill keywords."""
+    conditions = []
+    params = []
+
+    if title_keywords:
+        # Match any of the provided title keywords
+        title_cond = " OR ".join(["title LIKE ?" for _ in title_keywords])
+        conditions.append(f"({title_cond})")
+        params.extend([f"%{kw}%" for kw in title_keywords])
+
+    if skill_keywords:
+        # Search the job description for skill keywords
+        skill_cond = " OR ".join(["description LIKE ?" for _ in skill_keywords])
+        conditions.append(f"({skill_cond})")
+        params.extend([f"%{kw}%" for kw in skill_keywords])
+
+    if not conditions:
+        # No keywords found; return a simple query
+        return "SELECT * FROM job_postings LIMIT 100;", params
+
+    if title_keywords and skill_keywords:
+        # Require at least one title keyword AND one skill keyword for higher relevancy
+        where_clause = " AND ".join(conditions)
+    else:
+        # Only one type of keyword provided; use OR within that set
+        where_clause = conditions[0]
+
+    sql = f"SELECT * FROM job_postings WHERE {where_clause} LIMIT 100;"
     return sql, params
 
 # Run query on jobs.db
@@ -71,17 +107,25 @@ if selected_school:
         selected_major = st.selectbox("Select a Major:", majors)
 
         if selected_major:
-            job_keywords = load_major_keywords(selected_major)
+            title_keywords, skill_keywords = load_major_keywords(selected_major)
 
-            if not job_keywords:
-                st.warning("No job title keywords found for this major.")
+            if not title_keywords and not skill_keywords:
+                st.warning("No keywords found for this major.")
             else:
-                st.success(f"Searching job titles with {len(job_keywords)} keywords...")
-                query, params = build_query(job_keywords)
+                st.success(
+                    f"Searching with {len(title_keywords)} title and {len(skill_keywords)} skill keywords..."
+                )
+                query, params = build_query(title_keywords, skill_keywords)
                 results = query_jobs(query, params)
 
                 st.subheader(f"Job Postings for: {selected_major}")
-                st.write(f"Matched using job title keywords only.")
+                if title_keywords and skill_keywords:
+                    st.write("Matched using job title and skill keywords.")
+                elif title_keywords:
+                    st.write("Matched using job title keywords only.")
+                else:
+                    st.write("Matched using skill keywords only.")
+
                 st.dataframe(results)
 
                 if not results.empty:


### PR DESCRIPTION
## Summary
- refine SQL generation to require both title and skill keyword matches when possible
- clarify UI to say "job title and skill keywords" when both are used

## Testing
- `python -m pip install -r requirements.txt`
- `pytest -q`


------
https://chatgpt.com/codex/tasks/task_e_68507215f4cc8333a6af5986f5843b96